### PR TITLE
Stop base64 image exports 

### DIFF
--- a/PSModule/M365Documentation/Internal/Translation/Format-MsGraphData.ps1
+++ b/PSModule/M365Documentation/Internal/Translation/Format-MsGraphData.ps1
@@ -27,6 +27,8 @@ Function Format-MsGraphData(){
     $Value = $Value -replace "windows","win"
     $Value = $Value -replace "StoreforBusiness","SfB"
     $Value = $Value -replace "@odata.",""
+    if($null -ne $Value -and $Value -match "@{type=image"){
+        $Value = "[Image File]"
     if($null -ne $Value -and $Value -match "@{*"){
         $Value = $Value -replace "@{",""
         $Value = $Value -replace "}",""

--- a/PSModule/M365Documentation/Internal/Translation/Format-MsGraphData.ps1
+++ b/PSModule/M365Documentation/Internal/Translation/Format-MsGraphData.ps1
@@ -29,6 +29,7 @@ Function Format-MsGraphData(){
     $Value = $Value -replace "@odata.",""
     if($null -ne $Value -and $Value -match "@{type=image"){
         $Value = "[Image File]"
+    }
     if($null -ne $Value -and $Value -match "@{*"){
         $Value = $Value -replace "@{",""
         $Value = $Value -replace "}",""


### PR DESCRIPTION
When exporting iOS device features configurations containing a wallpaperImage, the image is exported as base64-encoded type=image/jpeg which does not look well in a Word export. Therefore replacing the value with "[Image File]".