### PR TITLE
Resolve special character issues in output file name

### DIFF
--- a/PSModule/M365Documentation/Internal/Output/Write-DocumentationCsvSection.ps1
+++ b/PSModule/M365Documentation/Internal/Output/Write-DocumentationCsvSection.ps1
@@ -20,7 +20,7 @@ Function Write-DocumentationCsvSection(){
         
         if($Data.Objects){
             $Path = $Path.Split([IO.Path]::GetInvalidFileNameChars()) -join ''
-            $Data.Objects | ConvertTo-Csv -NoTypeInformation -Delimiter ";" | Out-File -FilePath "$CsvPath\$Path.csv"
+            $Data.Objects | ConvertTo-Csv -NoTypeInformation -Delimiter ";" | Out-File -LiteralPath "$CsvPath\$Path.csv"
         }
         foreach($Section in $Data.SubSections){
             Write-DocumentationCsvSection -CsvPath $CsvPath -Data $Section -Path "$Path-$($Section.Title)"


### PR DESCRIPTION
Resolve the issue 
Out-File : Cannot perform operation because the wildcard path C:\myFolder\202306151717-Filename with [square brakets].csv did not resolve to a file.