### PR TITLE
Bug Fixes: Settings Catalog SubSettings, Resolving Objects and moved Write-DocumentationHTMLSection.ps1

### DIFF
--- a/PSModule/M365Documentation/Internal/Collector/Intune/Get-MdmConfigurationPolicy.ps1
+++ b/PSModule/M365Documentation/Internal/Collector/Intune/Get-MdmConfigurationPolicy.ps1
@@ -35,10 +35,10 @@ Function Get-MdmConfigurationPolicy(){
         $definition = $Definitions | Where-Object { $_.ID -eq $definitionId }
         $global:valueType = ($Instance.'@odata.type').Replace('#microsoft.graph.deviceManagementConfiguration', '').Replace('Instance', 'Value')
 
-        if ($valueType -eq 'groupSettingCollectionValue' -or $valueType -eq 'ChoiceSettingValue') {
+        if ($valueType -eq 'groupSettingCollectionValue') {
             foreach ($child in $Instance.$ValueType.Children | Where-Object { $_ -ne $null }) {
                 & $getValue -instance $child -definition $Definitions
-            }       
+            }    
         } else {
             $settingValue = [PSCustomObject]@{
                 DisplayName = $definition.displayName

--- a/PSModule/M365Documentation/Internal/Output/Write-DocumentationHTMLSection.ps1
+++ b/PSModule/M365Documentation/Internal/Output/Write-DocumentationHTMLSection.ps1
@@ -58,7 +58,7 @@ Function Write-DocumentationHTMLSection(){
                         }
                     }
 
-                    $retObj.BodyCode += Invoke-TransposeObject -InputObject $object |  ConvertTo-PshtmlTable
+                    $retObj.BodyCode += Invoke-TransposeObject -InputObject $objec |  ConvertTo-PshtmlTable
 
                 }
             }

--- a/PSModule/M365Documentation/Internal/Output/Write-DocumentationHTMLSection.ps1
+++ b/PSModule/M365Documentation/Internal/Output/Write-DocumentationHTMLSection.ps1
@@ -58,7 +58,7 @@ Function Write-DocumentationHTMLSection(){
                         }
                     }
 
-                    $retObj.BodyCode += Invoke-TransposeObject -InputObject $objec |  ConvertTo-PshtmlTable
+                    $retObj.BodyCode += Invoke-TransposeObject -InputObject $object |  ConvertTo-PshtmlTable
 
                 }
             }


### PR DESCRIPTION
I've noticed in our settings catalog docs, that sub settings are not documented. Here is an example from the Edge Settings Catalog Policy.

![image](https://github.com/user-attachments/assets/82b316f4-eb5f-4623-9293-fc116e67933e)

The Green marked part was documented correctly, the red marked part was missing from the documentation.
The reason for this seems, that in "Get-MdmConfigurationPolicy.ps1", the ScriptBlock "$getValues" uses the variable $ValueType, which gets set in the other Script Block "$getValue", but unfortunatly this variable is not inherited from the other Script Block. I applied a quick and dirty fix by declaring "$valueType" as global.

The second issue was, that settings like above are objects, and would output as "system.object[]" in the Docs. So I've added a small section to check if the Value is an object, and if yes, I output it as joined string.

Finally, I noticed in my last commit I had Write-DocumentationHTMLSection.ps1 in the wrong folder. Moved it to "Output" Folder. And a small bug when transposed objects should be outputted.

Now those sections document correctly:
![image](https://github.com/user-attachments/assets/de17a2d6-b51b-4a12-b8bb-dc1774fc3a2b)